### PR TITLE
np.get_include() added to setup.py\'s include_dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.core import setup, Extension
+import numpy as np
 
 module1 = Extension('_dpcore_py',
                     sources = ['dpcore_py.c'])
@@ -6,4 +7,6 @@ module1 = Extension('_dpcore_py',
 setup (name = '_dpcore_py',
        version = '0.0',
        description = 'Dynamic programming core routine',
-       ext_modules = [module1])
+       ext_modules = [module1],
+       include_dirs = [np.get_include()]
+)


### PR DESCRIPTION
I have some troubles with module compilation on my Mac with homebrew python.

```
$ python setup.py build
running build
running build_ext
building '_dpcore_py' extension
creating build
creating build/temp.macosx-10.9-x86_64-2.7
clang -fno-strict-aliasing -fno-common -dynamic -I/usr/local/include -I/usr/local/opt/sqlite/include -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c dpcore_py.c -o build/temp.macosx-10.9-x86_64-2.7/dpcore_py.o
dpcore_py.c:9:10: fatal error: 'numpy/arrayobject.h' file not found
#include <numpy/arrayobject.h>
         ^
1 error generated.
```

This commit fixes compilation (solution from http://stackoverflow.com/questions/2379898/make-distutils-look-for-numpy-header-files-in-the-correct-place):

```
$ python setup.py build
running build
running build_ext
building '_dpcore_py' extension
creating build
creating build/temp.macosx-10.9-x86_64-2.7
clang -fno-strict-aliasing -fno-common -dynamic -I/usr/local/include -I/usr/local/opt/sqlite/include -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/lib/python2.7/site-packages/numpy/core/include -I/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c dpcore_py.c -o build/temp.macosx-10.9-x86_64-2.7/dpcore_py.o
In file included from dpcore_py.c:9:
In file included from /usr/local/lib/python2.7/site-packages/numpy/core/include/numpy/arrayobject.h:4:
In file included from /usr/local/lib/python2.7/site-packages/numpy/core/include/numpy/ndarrayobject.h:17:
In file included from /usr/local/lib/python2.7/site-packages/numpy/core/include/numpy/ndarraytypes.h:1804:
/usr/local/lib/python2.7/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning:
      "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-W#warnings]
#warning "Using deprecated NumPy API, disable it by " \
 ^
dpcore_py.c:25:20: warning: unused variable 'd3' [-Wunused-variable]
    double d1, d2, d3, v;
                   ^
dpcore_py.c:31:9: warning: unused variable 'ii' [-Wunused-variable]
    int ii;
        ^
3 warnings generated.
creating build/lib.macosx-10.9-x86_64-2.7
clang -bundle -undefined dynamic_lookup -L/usr/local/lib -L/usr/local/opt/sqlite/lib build/temp.macosx-10.9-x86_64-2.7/dpcore_py.o -o build/lib.macosx-10.9-x86_64-2.7/_dpcore_py.so
```
